### PR TITLE
Generate token

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -34,9 +34,17 @@ jobs:
 
           ./scripts/auto-update.sh
 
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: 412514
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Create tag
         uses: actions/github-script@v6
         with:
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const { PUBLISH_VERSION } = process.env
             const tag = `v${PUBLISH_VERSION}`;

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -16,9 +16,6 @@ jobs:
   build:
     name: Package and publish
     runs-on: ubuntu-latest
-    permissions:
-      # workflow triggered from tag creation can't run w/o this permission
-      actions: write
     steps:
       - name: Checkout current branch (full)
         uses: actions/checkout@v2
@@ -37,6 +34,10 @@ jobs:
 
           ./scripts/auto-update.sh
 
+      # The original GITHUB_TOKEN has all it needs to create the tag
+      # but when it does, the CI workflow that should run, will not
+      # To workaround this issue, we create a temporary token, with more
+      # permissions to create tag
       - name: Generate token
         id: generate-token
         uses: tibdex/github-app-token@v2

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0


### PR DESCRIPTION
So to activate the token create action on the CI we need:

1. to register a github app, I created one on my account
2. to create a private key for that app, I did it and I added it to the secret of the repo (also on the API Registry 1password vault) - APP_PRIVATE_KEY
3. install the app in the organization, i did that, see attach screenshot