### PR TITLE
Add version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Maven Central](https://img.shields.io/maven-central/v/com.disneystreaming.smithy/aws-kinesis-spec)
+
 #### aws-sdk-specs
 
 This repository aims at building and publishing artifacts containing the smithy specifications for the AWS SDK.


### PR DESCRIPTION
Picked the aws-kinesis-spec, no reason, just one of the many artifacts that's published.

![Screenshot 2023-10-24 at 16 24 28](https://github.com/disneystreaming/aws-sdk-smithy-specs/assets/5230460/cfa7a590-49bc-4f76-a25b-095db0e77fd5)
